### PR TITLE
Exploring the primitives offered with Play 2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,25 @@ def theCatsVersion(scalaVersion: String): String =
     case _             => throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
 
+// Play 2.3
+lazy val play23_monad = project
+  .in(file("play23/play-monad"))
+  .settings(
+    sharedSettings ++ Seq[Setting[_]](
+      name := "play23-monad",
+      scalaVersion := scala_2_11Version,
+      crossScalaVersions := List(scala_2_11Version, scala_2_10Version),
+      libraryDependencies ++= Seq(
+        "org.typelevel"      %% "cats-core"            % theCatsVersion(scalaVersion.value),
+        "com.typesafe.play"  %% "play"                 % "2.3.10",
+        "org.scalatest"      %% "scalatest"            % "3.2.7" % "test"
+      ),
+      addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.3" cross CrossVersion.full),
+      // The Typesafe repository
+      resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
+    ): _*
+  )
+
 // Play 2.4
 lazy val play24_monad = project
   .in(file("play24/play-monad"))
@@ -101,4 +120,4 @@ lazy val root = project
       publish / skip := true
     ): _*
   )
-  .aggregate(play24_monad, play25_monad)
+  .aggregate(play23_monad, play24_monad, play25_monad)

--- a/play23/play-monad/src/main/scala/dev/playmonad/MonadicAction.scala
+++ b/play23/play-monad/src/main/scala/dev/playmonad/MonadicAction.scala
@@ -1,0 +1,85 @@
+package dev.playmonad
+
+import cats.{CoflatMap, Monad, MonadError}
+import cats.data.{EitherT, IndexedStateT}
+import play.api.libs.iteratee.{Done, Input, Iteratee}
+import play.api.mvc.{BodyParser, EssentialAction, RequestHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+sealed trait RequestReader
+case class HeaderReader(requestHeader: RequestHeader)                           extends RequestReader
+case class HeaderReaderHeaderReader(requestHeader: RequestHeader)               extends RequestReader
+case class BodyReader[A](accumulator: Iteratee[Array[Byte], Either[Result, A]]) extends RequestReader
+
+trait MonadicActionImplicits {
+  implicit val ec: ExecutionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext
+  implicit val futureInstances: MonadError[Future, Throwable] with CoflatMap[Future] with Monad[Future] =
+    cats.implicits.catsStdInstancesForFuture
+}
+
+object HeaderReader extends MonadicActionImplicits {
+  type Aux[A] = IndexedStateT[EitherT[Future, Result, *], HeaderReader, HeaderReader, A]
+
+  def withHeadersM[A](f: RequestHeader => Future[Either[Result, A]]): HeaderReader.Aux[A] =
+    IndexedStateT[EitherT[Future, Result, *], HeaderReader, HeaderReader, A] { state =>
+      EitherT[Future, Result, (HeaderReader, A)](f(state.requestHeader).map(_.right.map(value => (state, value))))
+    }
+
+  def withHeaders[A](f: RequestHeader => Either[Result, A]): HeaderReader.Aux[A] =
+    IndexedStateT[EitherT[Future, Result, *], HeaderReader, HeaderReader, A] { state =>
+      EitherT[Future, Result, (HeaderReader, A)](
+        Future.successful(f(state.requestHeader).right.map(v => (state, v)))
+      )
+    }
+
+  def withValue[A](value: Future[A]): HeaderReader.Aux[A] =
+    IndexedStateT[EitherT[Future, Result, *], HeaderReader, HeaderReader, A] { state =>
+      EitherT[Future, Result, (HeaderReader, A)](value.map(v => Right((state, v))))
+    }
+
+  def withValue[A](value: Either[Result, A]): HeaderReader.Aux[A] =
+    IndexedStateT[EitherT[Future, Result, *], HeaderReader, HeaderReader, A] { state =>
+      EitherT[Future, Result, (HeaderReader, A)](Future.successful(value.right.map(v => (state, v))))
+    }
+
+  def withValue[A](value: A): HeaderReader.Aux[A] =
+    IndexedStateT[EitherT[Future, Result, *], HeaderReader, HeaderReader, A] { state =>
+      EitherT[Future, Result, (HeaderReader, A)](Future.successful(Right((state, value))))
+    }
+
+  def withResult[A](value: Result): HeaderReader.Aux[A] =
+    IndexedStateT[EitherT[Future, Result, *], HeaderReader, HeaderReader, A] { _ =>
+      EitherT[Future, Result, (HeaderReader, A)](Future.successful(Left(value)))
+    }
+}
+
+object BodyReader extends MonadicActionImplicits {
+  type Aux[Body, A] = IndexedStateT[EitherT[Future, Result, *], HeaderReader, BodyReader[Body], Future[A]]
+
+  def withBody[A](bodyParser: BodyParser[A]): BodyReader.Aux[A, A] =
+    IndexedStateT[EitherT[Future, Result, *], HeaderReader, BodyReader[A], Future[A]] { state =>
+      val promise = Promise[A]()
+
+      val bd = BodyReader(bodyParser.apply(state.requestHeader).map {
+        case Left(errorResult) => Left(errorResult)
+        case Right(a) =>
+          promise.success(a) // unblocks `result` for completion
+          Right(a)
+      })
+
+      EitherT[Future, Result, (BodyReader[A], Future[A])](Future.successful(Right((bd, promise.future))))
+    }
+}
+
+object MonadicAction extends MonadicActionImplicits {
+  def apply[R <: RequestReader, A](
+      reader: IndexedStateT[EitherT[Future, Result, *], HeaderReader, R, A]
+  )(implicit solver: RequestReaderSolver[R, A]): EssentialAction =
+    EssentialAction { request =>
+      Iteratee.flatten(reader.run(HeaderReader(request)).value.map {
+        case Right((r, a)) => solver.makeResult(r, a)
+        case Left(result)  => Done[Array[Byte], Result](result, Input.EOF)
+      })
+    }
+}

--- a/play23/play-monad/src/main/scala/dev/playmonad/RequestReaderSolver.scala
+++ b/play23/play-monad/src/main/scala/dev/playmonad/RequestReaderSolver.scala
@@ -1,0 +1,57 @@
+package dev.playmonad
+
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.iteratee.{Done, Input, Iteratee}
+import play.api.mvc.Result
+
+import scala.annotation.implicitNotFound
+import scala.concurrent.Future
+
+/** Implicit proof that from RequestReader and a value of type A, an Action result can be built */
+@implicitNotFound(
+  "\n\nA RequestReaderSolver implicit for state ${R} and value ${A} could not be found." +
+    " This is needed so the MonadicAction can convert this expression to a Play Action." +
+    " When a MonadicAction ends up with a Result or a Future[Result] in either HeaderReader or BodyReader states, the built in" +
+    " RequestReaderSolvers will be found automatically, no import is needed." +
+    "\n - The R type is ${R} and the A type is ${A}:" +
+    "\n   - If R is a dev.playmonad.HeaderReader" +
+    "\n     - A should be play.api.mvc.Result or scala.concurrent.Future[play.api.mvc.Result]." +
+    "\n     - Otherwise you are using a custom extension and should import a RequestReaderSolver for this type." +
+    "\n   - If R is a dev.playmonad.BodyReader[x]" +
+    "\n     - A should be a scala.concurrent.Future[play.api.mvc.Result]. You should map or flatMap on the body." +
+    "\n     - Otherwise you are using a custom extension and should import a RequestReaderSolver for this type." +
+    "\n   - Otherwise it's possible this was built using unsupported states." +
+    "\n\n"
+)
+trait RequestReaderSolver[R <: RequestReader, A] {
+  def makeResult(reader: R, result: A): Iteratee[Array[Byte], Result]
+}
+
+object RequestReaderSolver {
+
+  /** A HeaderReader of Result can be turned into a Play Action */
+  implicit object HeaderResultSolver extends RequestReaderSolver[HeaderReader, Result] {
+    override def makeResult(reader: HeaderReader, result: Result): Iteratee[Array[Byte], Result] =
+      Done(result, Input.EOF)
+  }
+
+  /** A HeaderReader of Future[Result] can be turned into a Play Action */
+  implicit object HeaderFutureResultSolver extends RequestReaderSolver[HeaderReader, Future[Result]] {
+    override def makeResult(reader: HeaderReader, result: Future[Result]): Iteratee[Array[Byte], Result] =
+      Iteratee.flatten(result.map(Done(_, Input.EOF)))
+  }
+
+  /** A BodyReader of Result could be turned into a Play Action but since body returns Future[A],
+    * the user should be chaining on it instead of producing a Result. */
+//  implicit def BodyResultSolver[A]: RequestReaderSolver[BodyReader[A], Result] =
+
+  /** A BodyReader of Future[Result] can be turned into a Play Action */
+  implicit def BodyFutureResultSolver[A]: RequestReaderSolver[BodyReader[A], Future[Result]] =
+    new RequestReaderSolver[BodyReader[A], Future[Result]] {
+      override def makeResult(reader: BodyReader[A], result: Future[Result]): Iteratee[Array[Byte], Result] =
+        reader.accumulator.mapM {
+          case Left(errorResult) => Future.successful(errorResult)
+          case Right(_)          => result
+        }
+    }
+}


### PR DESCRIPTION
- Added Play 2.3
- Exploring usage of several fluent primitives in HeaderReader object
- Removed `RequestReaderSolvers` for BodyReader and Result, user should always end up with a Future[Result]